### PR TITLE
Fixed typo

### DIFF
--- a/Source/Module.cs
+++ b/Source/Module.cs
@@ -56,7 +56,7 @@ namespace HFYBot
 		/// <summary>
 		/// Representing the module has been disabled and will not respond to external input.
 		/// </summary>
-		Diabled,
+		Disabled,
 		/// <summary>
 		/// Representing the module has failed in some way, and should be restarted. Some modules may atempt to restart themselves.
 		/// </summary>


### PR DESCRIPTION
Changed "Diabled" [sic] to "Disabled", assuming it's a typo rather then some strange acronym. Should be mergable without any problems as only 1 character was added.